### PR TITLE
Fix to the overflowing of tables off the page

### DIFF
--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -12,7 +12,7 @@ col_list = ['country', 'city', 'zipcode', 'latitude', 'longitude','Month', 'week
             ]
 
 class GeneratedTable:
-    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=1, font_size='normalsize', landscape=False): 
+    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=1, font_size=12, landscape=False): 
         self.rows = rows
         self.columns = columns 
         self.row_lines = row_lines
@@ -53,9 +53,7 @@ class GeneratedTable:
 
         # Trim column amount if table overflows outside of page
         landscape_mult = 1 if self.geometry_options['landscape']==True else 110/150
-        font_size_mult = {'normalsize':1}
-        # insert font_type and landscape dicts as well
-        char_thresh = 150 * landscape_mult * font_size_mult[self.font_size]
+        char_thresh = 150 * landscape_mult * 12/self.font_size
         col_char_width = []
         for col in list(self.df.columns.values):
             col_char_width.append(max([len(str(col))] + self.df[col].astype(str).str.len().tolist()) + 2)  # max string length of column (or column name if bigger) plus 2 characters
@@ -73,8 +71,7 @@ class GeneratedTable:
         if not os.path.exists(self.path):
             os.makedirs('./generated_tables/' + self.filename)
 
-        doc = pl.Document(geometry_options=self.geometry_options, font_size=self.font_size)
-        doc.preamble.append(pl.Command('usepackage', 'helvet'))
+        doc = pl.Document(geometry_options=self.geometry_options, font_size='')
         if self.row_lines == True and self.multi_row == False:
             with doc.create(pl.Center()) as centered:
                 with centered.create(pl.LongTable(self.table_spec, row_height=self.row_height)) as table:

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -60,7 +60,7 @@ class GeneratedTable:
 
         # Trim column amount if table overflows outside of page
         landscape_mult = 1 if self.geometry_options['landscape']==True else 100/150
-        font_mult = (12/self.font_size)**0.75
+        font_mult = np.exp(-0.05*self.font_size + 0.5)
         char_thresh = 150 * landscape_mult * font_mult
         col_char_width = []
         for col in list(self.df.columns.values):

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -12,7 +12,7 @@ col_list = ['country', 'city', 'zipcode', 'latitude', 'longitude','name_month', 
            ]
             
 class GeneratedTable:
-    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=None, font_size=12, landscape=False): 
+    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=1.25, font_size=12, landscape=False): 
         self.rows = rows
         self.columns = columns 
         self.row_lines = row_lines
@@ -23,11 +23,10 @@ class GeneratedTable:
             'landscape':landscape
         }
         self.multi_row = multi_row
-        
-        if row_height is None:
-            self.row_height = self.font_size/12
+        if row_height < 1.25:
+            self.row_height = 1.25
         else:
-            self.row_height = row_height
+            self.row_height = row_height  # row height value is relative to font size (so automatically adjusts with it)
 
         if self.multi_row == True and (self.row_lines == False or self.vertical_lines == False):
             raise Exception('Cannot create table with multi-rows and with no vertical and horizontal lines')
@@ -60,8 +59,9 @@ class GeneratedTable:
                     self.df.loc[row,self.df.columns[0]] = ''
 
         # Trim column amount if table overflows outside of page
-        landscape_mult = 1 if self.geometry_options['landscape']==True else 110/150
-        char_thresh = 150 * landscape_mult * 12/self.font_size
+        landscape_mult = 1 if self.geometry_options['landscape']==True else 100/150
+        font_mult = (12/self.font_size)**0.75
+        char_thresh = 150 * landscape_mult * font_mult
         col_char_width = []
         for col in list(self.df.columns.values):
             col_char_width.append(max([len(str(col))] + self.df[col].astype(str).str.len().tolist()) + 2)  # max string length of column (or column name if bigger) plus 2 characters

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -12,7 +12,7 @@ col_list = ['country', 'city', 'zipcode', 'latitude', 'longitude','name_month', 
            ]
             
 class GeneratedTable:
-    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=1, font_size=12, landscape=False): 
+    def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=None, font_size=12, landscape=False): 
         self.rows = rows
         self.columns = columns 
         self.row_lines = row_lines
@@ -23,7 +23,11 @@ class GeneratedTable:
             'landscape':landscape
         }
         self.multi_row = multi_row
-        self.row_height = row_height
+        
+        if row_height is None:
+            self.row_height = self.font_size/12
+        else:
+            self.row_height = row_height
 
         if self.multi_row == True and (self.row_lines == False or self.vertical_lines == False):
             raise Exception('Cannot create table with multi-rows and with no vertical and horizontal lines')

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -59,9 +59,9 @@ class GeneratedTable:
                     self.df.loc[row,self.df.columns[0]] = ''
 
         # Trim column amount if table overflows outside of page
-        landscape_mult = 1 if self.geometry_options['landscape']==True else 100/150
+        landscape_mult = 1 if self.geometry_options['landscape']==True else 100/140
         font_mult = np.exp(-0.05*self.font_size + 0.5)
-        char_thresh = 150 * landscape_mult * font_mult
+        char_thresh = 140 * landscape_mult * font_mult
         col_char_width = []
         for col in list(self.df.columns.values):
             col_char_width.append(max([len(str(col))] + self.df[col].astype(str).str.len().tolist()) + 2)  # max string length of column (or column name if bigger) plus 2 characters

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 import numpy as np
 import random
+import logging
 
 myDB= dbgen.pydb()
 col_list = ['country', 'city', 'zipcode', 'latitude', 'longitude','name_month', 'weekday', 'year', 'time', 'date', 'email','company', 'job_title', 'phone', 'license_plate'
@@ -28,9 +29,13 @@ class GeneratedTable:
             raise Exception('Cannot create table with multi-rows and with no vertical and horizontal lines')
         
         if self.columns > 15:
-            raise Exception('Cannot generate that may columns')
+            self.columns = 15
+            logging.warning('Cannot generate that many columns, shrunk down to 15')
 
         self.generate_df(rows)
+
+        if self.columns < columns:
+            logging.warning('Generated table shrunk from ' + str(columns) + ' columns to ' + str(self.columns) + ' due to it overflowing off the page')
 
         if self.vertical_lines ==  True:
             self.table_spec = '|c'

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -1,14 +1,17 @@
-import pydbgen
 import pylatex as pl
 import shortuuid as sd
 from pydbgen import pydbgen as dbgen
 import os
 import pandas as pd
 import numpy as np
+import random
 
 myDB= dbgen.pydb()
 
 geometry_options = {'margin': '0.7in'}
+col_list = ['country', 'city', 'zipcode', 'latitude', 'longitude','Month', 'weekday', 'year', 'time', 'date', 'email','company', 'Job_title', 'phone number', 'license_plate'
+            
+]
 
 class GeneratedTable:
     def __init__(self, rows=10, columns=5, row_lines=None, vertical_lines=None, margin='0.7in', multi_row=False, row_height=None): 
@@ -23,20 +26,24 @@ class GeneratedTable:
         self.row_height = row_height
 
         if self.vertical_lines ==  True:
-            self.table_spec = 'c|c|c|c|c'
+            self.table_spec = '|c'
+            self.table_spec = self.table_spec*self.columns + '|'
         else:
-            self.table_spec = 'ccccc'
+            self.table_spec = 'c'
+            self.table_spec*self.columns
             
         if self.multi_row == True and (self.row_lines == False or self.vertical_lines == False):
             raise Exception('Cannot create table with multi-rows with no vertical and horizantal lines')
+        
+        if self.columns > 15:
+            raise Exception('Cannot generate that may columns')
 
         self.generate_df(rows)
 
 
     def generate_df(self,rows):
         self.df = myDB.gen_dataframe(
-        rows,fields=['name','city','phone',
-        'license_plate','email'],
+        rows,fields=self.generate_fields(),
         real_email=False,phone_simple=True)
 
         if self.multi_row == True:
@@ -55,6 +62,7 @@ class GeneratedTable:
         if self.row_lines == True and self.multi_row == False:
             with doc.create(pl.Center()) as centered:
                 with centered.create(pl.LongTable(self.table_spec, row_height=self.row_height)) as table:
+                    table.add_hline()
                     table.add_row(list(self.df.columns))
                     table.add_hline()
                     for row in self.df.index:
@@ -65,6 +73,7 @@ class GeneratedTable:
         elif self.row_lines == True and self.multi_row == True :
             with doc.create(pl.Center()) as centered:
                 with centered.create(pl.LongTable(self.table_spec)) as table:
+                    table.add_hline()
                     table.add_row(list(self.df.columns))
                     table.add_hline()
                     for row in self.df.index:
@@ -114,5 +123,13 @@ class GeneratedTable:
 
     def get_filename(self):
         return self.filename
-        
+    
+    def generate_fields(self):
+        fields = ['name']
+        tmp_list = random.sample(col_list, self.columns-1)
+        fields = fields + tmp_list
+
+        return fields
+
+
    

--- a/table_processing/GeneratedTable.py
+++ b/table_processing/GeneratedTable.py
@@ -20,7 +20,8 @@ class GeneratedTable:
         self.row_lines = row_lines
         self.vertical_lines = vertical_lines
         self.geometry_options = {
-            'vmargin':margin
+            'margin':margin,
+            'landscape':True
         }
         self.multi_row = multi_row
         self.row_height = row_height

--- a/table_processing/Table.py
+++ b/table_processing/Table.py
@@ -123,8 +123,8 @@ class Table:
         rows = []
         for row in row_images:
             row_cell_text = []
-            #row.show()
             if row.size[1] > 0:
+                # row.show()
                 cells = self.get_cropped_columns(row)
                 for cell in cells:
                     width, height = cell.size

--- a/table_processing/TableMetrics.ipynb
+++ b/table_processing/TableMetrics.ipynb
@@ -379,7 +379,12 @@
     "    # Run all metrics for each table\n",
     "    for t in tables:\n",
     "        df1, df2 = tables[t]\n",
-    "        results_lst.append(all_metrics(df1, df2))\n",
+    "        # Skip metrics if table has 0x0 dimensions\n",
+    "        if (df1.shape == (0,0)) | (df2.shape == (0,0)):  \n",
+    "            results_lst.append({'Overlap':0, 'String Similarity':0, 'Completeness':0, \n",
+    "                                'Purity':0, 'Precision':0, 'Recall':0})\n",
+    "        else:\n",
+    "            results_lst.append(all_metrics(df1, df2))\n",
     "    # Return dataframe with all metrics (columns) for each table (rows)\n",
     "    return pd.DataFrame(results_lst, index=tables.keys())"
    ]

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -14,9 +14,9 @@ tables = {}
 failed_tables = []
 
 # Loop for n # of tables
-for i in range(0,3):
+for i in range(0,1):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=12, landscape=False)
+    genr_table = GeneratedTable(rows=10, columns=5, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=12, landscape=False)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -14,9 +14,9 @@ tables = {}
 failed_tables = []
 
 # Loop for n # of tables
-for i in range(0,1):
+for i in range(0,3):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=8, landscape=True)
+    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=24, landscape=False)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -16,7 +16,7 @@ failed_tables = []
 # Loop for n # of tables
 for i in range(0,1):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=10, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1, font_size='normalsize', landscape=False)
+    genr_table = GeneratedTable(rows=10, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1, font_size=24, landscape=False)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -4,6 +4,7 @@ from Table_Detector import Table_Detector
 from table_metrics import test_tables
 import pandas as pd
 import numpy as np
+# xlsxwriter not imported, but needs to be downloaded in environment
 import logging
 logging.basicConfig(filename='benchmarking_log', filemode='a', datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.WARNING, format='[%(asctime)s][%(levelname)s] %(message)s\n')
@@ -15,12 +16,13 @@ failed_tables = []
 # Loop for n # of tables
 for i in range(0,1):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=5, columns=5, row_lines=True, vertical_lines=True)
+    genr_table = GeneratedTable(rows=10, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1, font_size='normalsize', landscape=False)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()
     logging.warning('Generated table ' + t_name)
     file_path = 'generated_tables/' + t_name + '/'  + t_name
+    true_table.to_excel(file_path + '_true.xlsx', index = False)
     # Detect from pdf, export to and read from excel processed table
     try:
         detc_table = Table_Detector(file_path+'.pdf')

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -32,6 +32,7 @@ for i in range(0,1):
         read_table = pd.read_excel(file_path+'.xlsx')
         # Store true and read tables
     except IndexError:  # could not detect table from pdf
+        logging.error('Could not detect table from pdf ' + t_name)
         read_table = pd.DataFrame()
         failed_tables.append(t_name)
     tables[t_name] = [true_table, read_table]

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -16,7 +16,7 @@ failed_tables = []
 # Loop for n # of tables
 for i in range(0,1):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=10, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1, font_size=18, landscape=False)
+    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=8, landscape=True)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()

--- a/table_processing/benchmark_pipeline.py
+++ b/table_processing/benchmark_pipeline.py
@@ -16,7 +16,7 @@ failed_tables = []
 # Loop for n # of tables
 for i in range(0,3):
     # Generate, store, and export to pdf true table
-    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=24, landscape=False)
+    genr_table = GeneratedTable(rows=15, columns=15, row_lines=True, vertical_lines=True, margin='0.7in', multi_row=False, row_height=1.25, font_size=12, landscape=False)
     true_table = genr_table.df
     genr_table.to_pdf()
     t_name = genr_table.get_filename()

--- a/table_processing/table_metrics.py
+++ b/table_processing/table_metrics.py
@@ -163,6 +163,11 @@ def test_tables(tables):
     # Run all metrics for each table
     for t in tables:
         df1, df2 = tables[t]
-        results_lst.append(all_metrics(df1, df2))
+        # Skip metrics if table has 0x0 dimensions
+        if (df1.shape == (0,0)) | (df2.shape == (0,0)):  
+            results_lst.append({'Overlap':0, 'String Similarity':0, 'Completeness':0, 
+                                'Purity':0, 'Precision':0, 'Recall':0})
+        else:
+            results_lst.append(all_metrics(df1, df2))
     # Return dataframe with all metrics (columns) for each table (rows)
     return pd.DataFrame(results_lst, index=tables.keys())


### PR DESCRIPTION
- added block that truncates dataframe based on df width in terms of characters until it is expected to fit on the page
- takes into account font size and page orientation (landscape vs portrait)

TO DO:
- get pylatex to apply the fontsize onto the pdf document output of the table