### PR TITLE
Remove separator character at start and end of string ("|")

### DIFF
--- a/table_processing/Table.py
+++ b/table_processing/Table.py
@@ -95,7 +95,10 @@ class Table:
                         #self.plot_image(cell)
                         ocr_text = pytesseract.image_to_string(cell).replace('\n','')  # replace extra empty line characters added by the OCR
                         if ocr_text[len(ocr_text) - len(ocr_text.lstrip())] == '|':  # verify if separator character at start (ignoring whitespaces) of string
-                            ocr_text = ocr_text[len(ocr_text) - len(ocr_text.lstrip()) + 1:].lstrip()
+                            ocr_text = ocr_text[len(ocr_text) - len(ocr_text.lstrip()) + 1:]             
+                        if ocr_text[-(len(ocr_text) - len(ocr_text.rstrip()) + 1)] == '|':  # verify if separator character at end (ignoring whitespaces) of string
+                            ocr_text = ocr_text[:-(len(ocr_text) - len(ocr_text.rstrip()) + 1)]
+                        ocr_text = ocr_text.strip()  # remove all leading and trailing whitespaces
                         row_cell_text.append(ocr_text)
                         #print(ocr_text)
                 rows.append(row_cell_text)

--- a/table_processing/Table.py
+++ b/table_processing/Table.py
@@ -93,8 +93,11 @@ class Table:
                     if width > 0:
                         cell = cell.resize((int(width*2.5), int(height*2.5)))
                         #self.plot_image(cell)
-                        row_cell_text.append((pytesseract.image_to_string(cell)).replace('\n',''))  # replace extra empty line characters added by the OCR
-                        #print(row_cell_text[-1])
+                        ocr_text = pytesseract.image_to_string(cell).replace('\n','')  # replace extra empty line characters added by the OCR
+                        if ocr_text[len(ocr_text) - len(ocr_text.lstrip())] == '|':  # verify if separator character at start (ignoring whitespaces) of string
+                            ocr_text = ocr_text[len(ocr_text) - len(ocr_text.lstrip()) + 1:].lstrip()
+                        row_cell_text.append(ocr_text)
+                        #print(ocr_text)
                 rows.append(row_cell_text)
         if len(rows) < 1:  # if read table is only one row
             rows.append(['']*len(rows[0]))

--- a/table_processing/Table.py
+++ b/table_processing/Table.py
@@ -94,10 +94,11 @@ class Table:
                         cell = cell.resize((int(width*2.5), int(height*2.5)))
                         #self.plot_image(cell)
                         ocr_text = pytesseract.image_to_string(cell).replace('\n','')  # replace extra empty line characters added by the OCR
-                        if ocr_text[len(ocr_text) - len(ocr_text.lstrip())] == '|':  # verify if separator character at start (ignoring whitespaces) of string
-                            ocr_text = ocr_text[len(ocr_text) - len(ocr_text.lstrip()) + 1:]             
-                        if ocr_text[-(len(ocr_text) - len(ocr_text.rstrip()) + 1)] == '|':  # verify if separator character at end (ignoring whitespaces) of string
-                            ocr_text = ocr_text[:-(len(ocr_text) - len(ocr_text.rstrip()) + 1)]
+                        if ocr_text != '':
+                            if ocr_text[len(ocr_text) - len(ocr_text.lstrip())] == '|':  # verify if separator character at start (ignoring whitespaces) of string
+                                ocr_text = ocr_text[len(ocr_text) - len(ocr_text.lstrip()) + 1:]             
+                            if ocr_text[-(len(ocr_text) - len(ocr_text.rstrip()) + 1)] == '|':  # verify if separator character at end (ignoring whitespaces) of string
+                                ocr_text = ocr_text[:-(len(ocr_text) - len(ocr_text.rstrip()) + 1)]
                         ocr_text = ocr_text.strip()  # remove all leading and trailing whitespaces
                         row_cell_text.append(ocr_text)
                         #print(ocr_text)


### PR DESCRIPTION
- Handled such that it is only removed if it is the first or last non-whitespace character in a string
- Since the inclusion of this character is usually accompanied by extra whitespace between it and the text, the ocr string is then trimmed of that whitespace after the removal