### PR TITLE
Hotfix: PDF causing JSON error when generating metadata report

### DIFF
--- a/file_processing/processors/pdf_processor.py
+++ b/file_processing/processors/pdf_processor.py
@@ -32,8 +32,8 @@ class PdfFileProcessor(FileProcessorStrategy):
                 metadata = reader.metadata
 
             self.metadata.update({'text': self.extract_text_from_pdf(self.file_path, reader),
-                                  'author': metadata.get('/Author'),
-                                  'producer': metadata.get('/Producer')})
+                                  'author': str(metadata.get('/Author')),
+                                  'producer': str(metadata.get('/Producer'))})
         else:
             self.metadata['has_password'] = True
 


### PR DESCRIPTION
* **Error**: Report generator was successfully loading all files, but crashing when generating the report
* **Cause**: A certain PDF had an `IndirectObject` in its producer field, which cannot be converted to a JSON object so `json.dumps` threw an error
* **Fix**: Forced all `author` and `producer` fields to be string objects in the `PDF Processor`