### PR TITLE
set torch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch==2.3.1
 pypdf==4.0.0
 python-docx==0.8.11
 extract-msg==0.45.0


### PR DESCRIPTION
Addresses issue #183. Torch version was likely being updated by one of the dependency packages. This sets the torch version to prevent that.