### PR TITLE
Added setuptools to the dev requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 # Upgrade pip, setuptools, and wheel
 RUN pip install -U \
     pip \
+    setuptools \
     wheel
 
 # Copy the requirements file and install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y \
 # Upgrade pip, setuptools, and wheel
 RUN pip install -U \
     pip \
-    setuptools \
     wheel
 
 # Copy the requirements file and install dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+setuptools
 file-processing-test-data @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-test-data.git@main
 file-processing-ocr @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-ocr.git@main
 file-processing-transcription @ git+https://github.com/hc-sc-ocdo-bdpd/file-processing-transcription.git@main


### PR DESCRIPTION
Needed for test cases to work without Docker.
Removed from Dockerfile as it is now in the requirements file.